### PR TITLE
Phase 3, Step 3.5: Implement Jar Publishing

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -4,6 +4,12 @@
 Working branch: `python-to-go`
 
 ## Recent Updates
+**December 30, 2025 3**: Completed Phase 3, Step 3.5 - Jar Publishing
+- Implemented `PublishNewJar()` method in `internal/minecraft/aumc.go`
+- Method checks jar file exists, commits to GitHub, creates MSM jargroup
+- Added `replaceAll()` helper function to `internal/minecraft/utils.go`
+- All tests passing, 0 linter issues
+
 **December 30, 2025 2**: Completed Phase 3, Step 3.4 - World Management (Delete)
 - Implemented `DeleteWorld(name)` method in `internal/minecraft/aumc.go`
 - Method backs up world via MSM, finds latest backup, copies to home directory
@@ -107,10 +113,10 @@ Bottom-up conversion with incremental testing. Each phase should be completed an
 - [x] Clean up MSM archives
 - [ ] Test: Delete test world in Docker environment
 
-### Step 3.5: Jar Publishing
-- [ ] Port `publish_new_jar()` method
-- [ ] Git operations (add, commit, push)
-- [ ] MSM jargroup creation
+### Step 3.5: Jar Publishing ✅
+- [x] Port `publish_new_jar()` method
+- [x] Git operations (add, commit, push)
+- [x] MSM jargroup creation
 - [ ] Test: Mock git operations
 
 ### Step 3.6: World Restoration (Optional)

--- a/internal/minecraft/aumc.go
+++ b/internal/minecraft/aumc.go
@@ -348,3 +348,94 @@ func (a *AuMc) DeleteWorld(name string) error {
 	fmt.Printf("World '%s' deleted successfully. Backup saved to %s\n", name, destPath)
 	return nil
 }
+
+// PublishNewJar commits the specified jar file to GitHub and creates a new jargroup in MSM
+func (a *AuMc) PublishNewJar() error {
+	buildConfig := &a.config.BuildConfig
+
+	// Step 1: Build filename from Minecraft version
+	filename := fmt.Sprintf("spigot-%s.jar", buildConfig.MinecraftVersion)
+	jarPath := filepath.Join(buildConfig.JarGitRepo, "jars", filename)
+
+	// Step 2: Check if jar file exists
+	if !fileExists(jarPath) {
+		return fmt.Errorf("the jar file is not in %s/jars. Did you build it?", buildConfig.JarGitRepo)
+	}
+
+	// Step 3: Commit and push to GitHub
+	fmt.Println("Committing new jar to GitHub...")
+
+	// Save current directory and change to git repo directory
+	originalDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalDir); err != nil {
+			fmt.Printf("Warning: failed to restore original directory: %v\n", err)
+		}
+	}()
+
+	if err := os.Chdir(buildConfig.JarGitRepo); err != nil {
+		return fmt.Errorf("failed to change to git repo directory: %w", err)
+	}
+
+	// Git add
+	cmd := exec.Command("git", "add", "-A")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git add failed: %w", err)
+	}
+
+	// Git commit
+	cmd = exec.Command("git", "commit", "-m", "New Minecraft jar added via script")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		// Check if there's nothing to commit
+		fmt.Printf("Warning: git commit failed (possibly nothing to commit): %v\n", err)
+	}
+
+	// Git push
+	cmd = exec.Command("git", "push", "origin", "master")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git push failed: %w", err)
+	}
+
+	fmt.Println("New jar committed to GitHub")
+
+	// Step 4: Create jargroup name and URL
+	// Convert "spigot-1.20.1.jar" -> "1_20_1"
+	// Remove "spigot-" prefix, remove ".jar" suffix, replace "." and "-" with "_"
+	jargroupName := buildConfig.MinecraftVersion
+	jargroupName = filepath.Base(jargroupName) // Remove any path components
+	jargroupName = replaceAll(jargroupName, ".", "_")
+	jargroupName = replaceAll(jargroupName, "-", "_")
+
+	jargroupURL := fmt.Sprintf("https://github.com/thehatchcloud/minecraft_jars/raw/master/jars/%s", filename)
+
+	// Step 5: Create MSM jargroup
+	fmt.Println("Adding the new jargroup...")
+	cmd = exec.Command("sudo", "msm", "jargroup", "create", jargroupName, jargroupURL)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to create jargroup: %w", err)
+	}
+
+	// Step 6: Download the latest jar
+	cmd = exec.Command("sudo", "msm", "jargroup", "getlatest", jargroupName)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to get latest jargroup: %w", err)
+	}
+
+	fmt.Println("Adding the latest jar is complete!")
+	fmt.Printf("New jargroup name is %s\n", jargroupName)
+
+	return nil
+}

--- a/internal/minecraft/utils.go
+++ b/internal/minecraft/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 // copyFile copies a file from src to dst
@@ -56,4 +57,9 @@ func dirExists(path string) bool {
 		return false
 	}
 	return info.IsDir()
+}
+
+// replaceAll replaces all occurrences of old with new in the string s
+func replaceAll(s, old, new string) string {
+	return strings.ReplaceAll(s, old, new)
 }


### PR DESCRIPTION
## Summary
Implements Step 3.5 of the migration plan: Jar Publishing functionality.

## Changes
- Added `PublishNewJar()` method to `AuMc` struct in `internal/minecraft/aumc.go`
  - Validates jar file exists in the git repo jars directory
  - Commits jar file to GitHub using git commands (add, commit, push)
  - Creates MSM jargroup with appropriate naming and URL
  - Downloads the latest jar using MSM
- Added `replaceAll()` helper function to `internal/minecraft/utils.go`
- Updated `MIGRATION_PLAN.md` to mark Step 3.5 as complete

## Testing
- ✅ All unit tests pass
- ✅ No linter issues (golangci-lint v2.7.2)
- ✅ Binary builds successfully
- ⚠️ Integration testing with Docker environment pending

## Migration Status
Phase 3 Business Logic Layer is now complete:
- ✅ Step 3.1: Core AuMc Struct
- ✅ Step 3.2: Build New Jar
- ✅ Step 3.3: World Management - Create
- ✅ Step 3.4: World Management - Delete
- ✅ Step 3.5: Jar Publishing
- ⏭️ Step 3.6: World Restoration (Optional)

Next: Phase 4 - CLI Layer (Cobra)